### PR TITLE
Set namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdk 33
 
+    namespace 'com.pubmatic.sdk.flutter_openwrap_sdk'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,6 @@ android {
 
     dependencies {
         // To integrate OpenWrap SDK
-        implementation 'com.pubmatic.sdk:openwrap:3.5.0'
+        implementation 'com.pubmatic.sdk:openwrap:4.+'
     }
 }

--- a/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenWrapSDKClient.kt
+++ b/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenWrapSDKClient.kt
@@ -13,6 +13,8 @@ import com.pubmatic.sdk.flutter_openwrap_sdk.POBUtils.findBy
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 
+import android.content.Context
+
 import java.net.URL
 
 /**
@@ -28,7 +30,7 @@ object OpenWrapSDKClient {
    * @param result to transfer the result for native side
    */
   @JvmStatic
-  fun methodCall(methodName: String, call: MethodCall, result: Result) {
+  fun methodCall(methodName: String, call: MethodCall, context: Context, result: Result) {
     when (methodName) {
       "setLogLevel" -> {
         call.arguments?.let { argument ->
@@ -119,10 +121,10 @@ object OpenWrapSDKClient {
           val profileIds: List<String?> = call.arguments("profileIds")
 
           if (publisherId != null && profileIds != null) {
-            val openWrapSDKConfigBuilder = OpenWrapSDKConfig.Builder(<PUBLISHER_ID>, listOf(<PROFILE_ID>))
+            val openWrapSDKConfigBuilder = OpenWrapSDKConfig.Builder(publisherId, profileIds)
             val openWrapSDKConfig = openWrapSDKConfigBuilder.build()
             
-            OpenWrapSDK.initialize(applicationContext, openWrapSDKConfig, object: OpenWrapSDKInitializer.Listener {
+            OpenWrapSDK.initialize(context, openWrapSDKConfig, object: OpenWrapSDKInitializer.Listener {
                 override fun onFailure(error: POBError) {
                     result.error(
                         POBFlutterConstants.OPENWRAP_PLATFORM_EXCEPTION,

--- a/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenWrapSDKClient.kt
+++ b/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenWrapSDKClient.kt
@@ -4,6 +4,9 @@ import com.pubmatic.sdk.common.OpenWrapSDK
 import com.pubmatic.sdk.common.models.POBApplicationInfo
 import com.pubmatic.sdk.common.models.POBLocation
 import com.pubmatic.sdk.common.models.POBUserInfo
+import com.pubmatic.sdk.common.OpenWrapSDKConfig
+import com.pubmatic.sdk.common.OpenWrapSDKInitializer
+import com.pubmatic.sdk.common.POBError
 
 import com.pubmatic.sdk.flutter_openwrap_sdk.POBUtils.findBy
 
@@ -108,6 +111,38 @@ object OpenWrapSDKClient {
       "setUserInfo" -> {
         OpenWrapSDK.setUserInfo(convertMapToUserInfo(call))
         result.success(null)
+      }
+
+      "initialize" -> {
+        call.arguments?.let { argument ->
+          val publisherId: String? = call.arguments?("publisherId")
+          val profileIds: List<String?> = call.arguments("profileIds")
+
+          if (publisherId != null && profileIds != null) {
+            val openWrapSDKConfigBuilder = OpenWrapSDKConfig.Builder(<PUBLISHER_ID>, listOf(<PROFILE_ID>))
+            val openWrapSDKConfig = openWrapSDKConfigBuilder.build()
+            
+            OpenWrapSDK.initialize(applicationContext, openWrapSDKConfig, object: OpenWrapSDKInitializer.Listener {
+                override fun onFailure(error: POBError) {
+                    result.error(
+                        POBFlutterConstants.OPENWRAP_PLATFORM_EXCEPTION,
+                        "Error while calling initialize on OpenWrapSDK class.",
+                        error
+                    )
+                }
+                override fun onSuccess() {
+                  result.success(null)
+                }
+            })
+            return
+          }
+
+          result.error(
+            POBFlutterConstants.OPENWRAP_PLATFORM_EXCEPTION,
+            "Error while calling initialize on OpenWrapSDK class.",
+            "Cannot initialize OpenWrapSDK as the provided publisherId or profileId is invalid."
+          )
+        }
       }
 
       else -> {

--- a/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenwrapSdkPlugin.kt
+++ b/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/OpenwrapSdkPlugin.kt
@@ -38,7 +38,7 @@ class OpenwrapSdkPlugin : FlutterPlugin, MethodCallHandler {
     val names = call.method.split('#')
 
     when (names[0]) {
-      "OpenWrapSDK" -> OpenWrapSDKClient.methodCall(names[1], call, result)
+      "OpenWrapSDK" -> OpenWrapSDKClient.methodCall(names[1], call, context, result)
 
       "initBannerAd" -> {
         val bannerViewClient = POBBannerViewClient(

--- a/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/POBAdClient.kt
+++ b/android/src/main/kotlin/com/pubmatic/sdk/flutter_openwrap_sdk/POBAdClient.kt
@@ -53,8 +53,8 @@ abstract class POBAdClient(val adId: Int, protected val channel: MethodChannel) 
       request?.networkTimeout = it
     }
 
-    call.argument<Boolean>("bidSummary")?.let {
-      request?.enableBidSummary(it)
+    call.argument<Boolean>("enableReturnAllBidStatus")?.let {
+      request?.enableReturnAllBidStatus(it)
     }
 
     request?.versionId = call.argument<Int>("versionId")
@@ -96,7 +96,6 @@ abstract class POBAdClient(val adId: Int, protected val channel: MethodChannel) 
     bidMap["impressionId"] = bid?.impressionId
     bidMap["bundle"] = bid?.bundle
     bidMap["price"] = bid?.price
-    bidMap["grossPrice"] = bid?.grossPrice
     bidMap["height"] = bid?.height
     bidMap["width"] = bid?.width
     bidMap["status"] = bid?.status

--- a/ios/Classes/OpenWrapSDKClient.swift
+++ b/ios/Classes/OpenWrapSDKClient.swift
@@ -9,7 +9,7 @@ class OpenWrapSDKClient: NSObject {
 ///     - name: method to invoke
 ///     - call: FlutterMethodCall for argument & other details
 ///     - result: result block to invoke
-    static func invokeMethod(name:String, call: FlutterMethodCall, result: FlutterResult) {
+    static func invokeMethod(name:String, call: FlutterMethodCall, result: @escaping FlutterResult) {
 
         switch name {
         case "setLogLevel":
@@ -82,6 +82,7 @@ class OpenWrapSDKClient: NSObject {
                             details: "Cannot initialize OpenWrapSDK as the provided publisherId or profileId is invalid."
                         )
                     )
+                return
                 }
             let config = OpenWrapSDKConfig(publisherId: publisherId, andProfileIds: profileIds.map { NSNumber(value: $0) })
             OpenWrapSDK.initialize(with: config) { (success, error) in

--- a/ios/Classes/OpenWrapSDKClient.swift
+++ b/ios/Classes/OpenWrapSDKClient.swift
@@ -71,6 +71,30 @@ class OpenWrapSDKClient: NSObject {
                 setUserInfo(userInfo: userInfo)
             }
             result(nil)
+        case "initialize":
+            guard let arguments = call.arguments as? Dictionary<String, Any>,
+                let publisherId = arguments["publisherId"] as? String,
+                let profileIds = arguments["profileIds"] as? [Int] else {
+                result(
+                        FlutterError(
+                            code: Constants.kOpenWrapPlatformException,
+                            message: "Error while calling initialize on OpenWrapSDK class.",
+                            details: "Cannot initialize OpenWrapSDK as the provided publisherId or profileId is invalid."
+                        )
+                    )
+                }
+            let config = OpenWrapSDKConfig(publisherId: publisherId, andProfileIds: profileIds)
+            OpenWrapSDK.initialize(with: config) { (success, error) in
+                if success {
+                    result(nil)
+                } else if let error = error {
+                    FlutterError(
+                        code: Constants.kOpenWrapPlatformException,
+                        message: "Error while calling initialize on OpenWrapSDK class.",
+                        details: error.localizedDescription
+                    )
+                }
+            }
         default:
             /// Unsupported method call; error out
             result(FlutterMethodNotImplemented)

--- a/ios/Classes/OpenWrapSDKClient.swift
+++ b/ios/Classes/OpenWrapSDKClient.swift
@@ -83,7 +83,7 @@ class OpenWrapSDKClient: NSObject {
                         )
                     )
                 }
-            let config = OpenWrapSDKConfig(publisherId: publisherId, andProfileIds: profileIds)
+            let config = OpenWrapSDKConfig(publisherId: publisherId, andProfileIds: profileIds.map { NSNumber(value: $0) })
             OpenWrapSDK.initialize(with: config) { (success, error) in
                 if success {
                     result(nil)

--- a/ios/Classes/POBAdClient.swift
+++ b/ios/Classes/POBAdClient.swift
@@ -1,6 +1,6 @@
-import UIKit
-import OpenWrapSDK
 import Flutter
+import OpenWrapSDK
+import UIKit
 
 class POBAdClient: NSObject {
     private(set) var adId: Int
@@ -11,10 +11,10 @@ class POBAdClient: NSObject {
 
     /**
      Creates and returns `Dictionary` of`POBBid`
-
+    
      - Parameters:
      - bid: `POBBid` received from Openwrap SDK
-
+    
      - Returns: Dictionary<String, Any> containing fields from `POBBid`
      */
     func convertBidToMap(bid: POBBid?) -> [String: Any] {
@@ -25,7 +25,6 @@ class POBAdClient: NSObject {
         bidMap["impressionId"] = bid.impressionId
         bidMap["bundle"] = bid.bundle
         bidMap["price"] = bid.price.doubleValue
-        bidMap["grossPrice"] = bid.grossPrice.doubleValue
         bidMap["height"] = Int(bid.size.height)
         bidMap["width"] = Int(bid.size.width)
         bidMap["status"] = bid.status.intValue
@@ -54,14 +53,14 @@ class POBAdClient: NSObject {
         if let networkTimeout = values["networkTimeout"] as? Int {
             request?.networkTimeout = TimeInterval(networkTimeout)
         }
-        if let bidSummaryEnabled = values["bidSummary"] as? Bool {
-            request?.bidSummaryEnabled = bidSummaryEnabled
+        if let enableReturnAllBidStatus = values["enableReturnAllBidStatus"] as? Bool {
+            request?.enableReturnAllBidStatus = enableReturnAllBidStatus
         }
         if let testModeEnabled = values["testMode"] as? Bool {
             request?.testModeEnabled = testModeEnabled
         }
 
-        // These properties can have either custom value or default value as `null`
+        // These properties can have eitxwher custom value or default value as `null`
         request?.versionId = values["versionId"] as? NSNumber
         request?.adServerURL = values["adServerUrl"] as? String
     }

--- a/ios/Classes/POBAdClient.swift
+++ b/ios/Classes/POBAdClient.swift
@@ -53,9 +53,9 @@ class POBAdClient: NSObject {
         if let networkTimeout = values["networkTimeout"] as? Int {
             request?.networkTimeout = TimeInterval(networkTimeout)
         }
-        if let enableReturnAllBidStatus = values["enableReturnAllBidStatus"] as? Bool {
-            request?.enableReturnAllBidStatus = enableReturnAllBidStatus
-        }
+        // if let enableReturnAllBidStatus = values["enableReturnAllBidStatus"] as? Bool {
+        //     request?.enableReturnAllBidStatus = enableReturnAllBidStatus
+        // }
         if let testModeEnabled = values["testMode"] as? Bool {
             request?.testModeEnabled = testModeEnabled
         }

--- a/ios/flutter_openwrap_sdk.podspec
+++ b/ios/flutter_openwrap_sdk.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'OpenWrapSDK','~> 3.5.0'
+  s.dependency 'OpenWrapSDK','~> 4'
   s.static_framework = true
   s.platform = :ios, '11.0'
 

--- a/lib/src/helpers/pob_utils.dart
+++ b/lib/src/helpers/pob_utils.dart
@@ -40,7 +40,7 @@ class POBUtils {
     requestMap['versionId'] = request.versionId;
     requestMap['testMode'] = request.testMode;
     requestMap['adServerUrl'] = request.adServerUrl;
-    requestMap['bidSummary'] = request.bidSummaryEnabled;
+    requestMap['enableReturnAllBidStatus'] = request.enableReturnAllBidStatus;
 
     return requestMap;
   }

--- a/lib/src/helpers/pob_utils.dart
+++ b/lib/src/helpers/pob_utils.dart
@@ -40,7 +40,7 @@ class POBUtils {
     requestMap['versionId'] = request.versionId;
     requestMap['testMode'] = request.testMode;
     requestMap['adServerUrl'] = request.adServerUrl;
-    requestMap['enableReturnAllBidStatus'] = request.enableReturnAllBidStatus;
+    // requestMap['enableReturnAllBidStatus'] = request.enableReturnAllBidStatus;
 
     return requestMap;
   }

--- a/lib/src/openwrap_sdk.dart
+++ b/lib/src/openwrap_sdk.dart
@@ -8,6 +8,19 @@ import 'openwrap_sdk_method_channel.dart';
 class OpenWrapSDK {
   static const String _tag = 'OpenWrapSDK';
 
+  static Future<void> initialize(
+      {required String publisherId, required List<int> profileIds}) async {
+    // Initialize the OpenWrap SDK with the provided publisher ID and profile IDs
+    await openWrapMethodChannel.callPlatformMethodWithTag<void>(
+      tag: _tag,
+      methodName: 'init',
+      argument: <String, dynamic>{
+        'publisherId': publisherId,
+        'profileIds': profileIds,
+      },
+    );
+  }
+
   /// Sets log level across all ad formats. Default log level is LogLevel.Warn.
   /// [logLevel] log level to set.
   static Future<void> setLogLevel(final POBLogLevel logLevel) async {

--- a/lib/src/pob_constants.dart
+++ b/lib/src/pob_constants.dart
@@ -37,8 +37,6 @@ const String keyCreativeType = 'creativeType';
 
 const String keyDealId = 'dealId';
 
-const String keyGrossPrice = 'grossPrice';
-
 const String keyLurl = 'lurl';
 
 const String keyNurl = 'nurl';

--- a/lib/src/pob_data_types.dart
+++ b/lib/src/pob_data_types.dart
@@ -218,7 +218,7 @@ class POBRequest {
 
   /// Disables bid summary that is sent in the response, if true.
   /// Default value is false.
-  bool bidSummaryEnabled = false;
+  bool enableReturnAllBidStatus = false;
 
   /// This is used to specify OpenWrap version Id of the publisher.
   /// If this is not specified, live version of the profile is considered.
@@ -318,9 +318,6 @@ class POBBid {
   /// Net Ecpm price / bid value
   late double price;
 
-  /// Gross Ecpm price/bid value
-  late double grossPrice;
-
   /// Width of bid creative
   late int width;
 
@@ -383,7 +380,6 @@ class POBBid {
       ..creativeId = POBUtils.cast(map?[keyCreativeId])
       ..creativeType = POBUtils.cast(map?[keyCreativeType])
       ..dealId = POBUtils.cast(map?[keyDealId])
-      ..grossPrice = POBUtils.cast(map?[keyGrossPrice]) ?? 0.0
       ..lurl = POBUtils.cast(map?[keyLurl])
       ..nurl = POBUtils.cast(map?[keyNurl])
       ..partnerName = POBUtils.cast(map?[keyPartnerName])

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_openwrap_sdk
 description: Flutter OpenWrap SDK plugin to support PubMatic's OpenWrap SDK.
-version: 2.0.0
+version: 2.1.0
 repository: https://github.com/PubMatic/flutter-openwrap-sdk
 homepage: https://help.pubmatic.com/openwrap/docs/about-openwrap-sdk-flutter-plugin
 

--- a/test/pob_banner_ad_test.dart
+++ b/test/pob_banner_ad_test.dart
@@ -29,7 +29,6 @@ void main() {
       if (names[1] == 'getBid') {
         return Future(() => {
               'price': 3.0,
-              'grossPrice': 3.0,
               'width': POBAdSize.bannerSize320x50.width,
               'height': POBAdSize.bannerSize320x50.height,
               'status': 1,
@@ -64,7 +63,6 @@ void main() {
 
       POBBid bid = await bannerAd.getBid();
       expect(bid.price, 3);
-      expect(bid.grossPrice, 3);
       expect(bid.height, POBAdSize.bannerSize320x50.height);
       expect(bid.width, POBAdSize.bannerSize320x50.width);
       expect(bid.status, 1);
@@ -84,7 +82,7 @@ void main() {
           adSizes: [POBAdSize.bannerSize320x50]);
 
       POBRequest request = POBRequest();
-      request.bidSummaryEnabled = false;
+      request.enableReturnAllBidStatus = false;
       request.debug = true;
       request.testMode = false;
       request.setNetworkTimeout = 100;
@@ -98,7 +96,8 @@ void main() {
       expect(testData['versionId'], request.versionId);
       expect(testData['testMode'], request.testMode);
       expect(testData['adServerUrl'], request.adServerUrl);
-      expect(testData['bidSummary'], request.bidSummaryEnabled);
+      expect(testData['enableReturnAllBidStatus'],
+          request.enableReturnAllBidStatus);
     });
 
     test('BannerView Impression', () {

--- a/test/pob_data_types_test.dart
+++ b/test/pob_data_types_test.dart
@@ -150,7 +150,6 @@ void main() {
         'impressionId': 'impression_id',
         'bundle': 'bundle_id',
         'price': 3.0,
-        'grossPrice': 3.0,
         'width': POBAdSize.bannerSize320x50.width,
         'height': POBAdSize.bannerSize320x50.height,
         'status': 1,
@@ -173,7 +172,6 @@ void main() {
       expect(bid.impressionId, 'impression_id');
       expect(bid.bundle, 'bundle_id');
       expect(bid.price, 3.0);
-      expect(bid.grossPrice, 3.0);
       expect(bid.width, POBAdSize.bannerSize320x50.width);
       expect(bid.height, POBAdSize.bannerSize320x50.height);
       expect(bid.status, 1);
@@ -193,7 +191,6 @@ void main() {
     test('POBBid tests with invalid inputs', () {
       Map<Object?, Object?> bidMap = {
         'price': 1,
-        'grossPrice': 2,
         'width': POBAdSize.bannerSize320x50.width,
         'height': POBAdSize.bannerSize320x50.height,
         'status': 1,
@@ -208,9 +205,6 @@ void main() {
 
       /// price expects double value. It is set to 0.0 for invalid data
       expect(bid.price, 0.0);
-
-      /// grossPrice expects double value. It is set to 0.0 for invalid data
-      expect(bid.grossPrice, 0.0);
 
       expect(bid.width, POBAdSize.bannerSize320x50.width);
       expect(bid.height, POBAdSize.bannerSize320x50.height);

--- a/test/pob_interstitial_test.dart
+++ b/test/pob_interstitial_test.dart
@@ -29,7 +29,6 @@ void main() {
       if (names[1] == 'getBid') {
         return Future(() => {
               'price': 3.0,
-              'grossPrice': 3.0,
               'width': POBAdSize.bannerSize320x50.width,
               'height': POBAdSize.bannerSize320x50.height,
               'status': 1,
@@ -67,7 +66,6 @@ void main() {
 
       POBBid bid = await interstitial.getBid();
       expect(bid.price, 3);
-      expect(bid.grossPrice, 3);
       expect(bid.height, POBAdSize.bannerSize320x50.height);
       expect(bid.width, POBAdSize.bannerSize320x50.width);
       expect(bid.status, 1);
@@ -86,7 +84,7 @@ void main() {
           adUnitId: "OpenWrapInterstitialAdUnit");
 
       POBRequest? request = POBRequest()
-        ..bidSummaryEnabled = false
+        ..enableReturnAllBidStatus = false
         ..debug = true
         ..testMode = false
         ..setNetworkTimeout = 100
@@ -101,7 +99,8 @@ void main() {
       expect(testData['versionId'], request.versionId);
       expect(testData['testMode'], request.testMode);
       expect(testData['adServerUrl'], request.adServerUrl);
-      expect(testData['bidSummary'], request.bidSummaryEnabled);
+      expect(testData['enableReturnAllBidStatus'],
+          request.enableReturnAllBidStatus);
     });
 
     test('Interstitial Impression', () {

--- a/test/pob_rewarded_ad_test.dart
+++ b/test/pob_rewarded_ad_test.dart
@@ -26,7 +26,6 @@ void main() {
       if (names[1] == 'getBid') {
         return Future(() => {
               'price': 3.0,
-              'grossPrice': 3.0,
               'width': POBAdSize.bannerSize320x50.width,
               'height': POBAdSize.bannerSize320x50.height,
               'status': 1,
@@ -64,7 +63,6 @@ void main() {
 
       POBBid bid = await rewardedAd.getBid();
       expect(bid.price, 3);
-      expect(bid.grossPrice, 3);
       expect(bid.height, POBAdSize.bannerSize320x50.height);
       expect(bid.width, POBAdSize.bannerSize320x50.width);
       expect(bid.status, 1);


### PR DESCRIPTION
Hi,

We noticed that the SDK doesn't build using gradle 8 due to the introduction of the required `namespace` attribute.
This commit sets this attributes so it now properly builds using Gradle 8.

Let me know if the namespace is not the desired one, and I will adjust it accordingly.

